### PR TITLE
Added support for FileStation CopyMove and Rename

### DIFF
--- a/Synology.FileStation/CopyMove/CopyMoveRequest.cs
+++ b/Synology.FileStation/CopyMove/CopyMoveRequest.cs
@@ -1,0 +1,58 @@
+﻿using Synology.Classes;
+using Synology.FileStation.CopyMove.Parameters;
+using Synology.FileStation.CopyMove.Results;
+using Synology.Parameters;
+
+namespace Synology.FileStation.CopyMove
+{
+    /// <summary>
+    /// Copy / Move operations from the Synology API
+    /// This is a non-blocking API. You need to start to copy/move files with start method. Then, you should poll requests with status method to get the progress status, or make a request with stop method to cancel the operation.
+    /// </summary>
+    public class CopyMoveRequest : SynologyRequest
+    {
+        public CopyMoveRequest(SynologyApi parentApi) : base(parentApi, "entry.cgi", "FileStation.CopyMove")
+        {
+        }
+
+        /// <summary>
+        /// Start to copy/move files.
+        /// </summary>
+        /// <param name="parameters">Parameters of the operation</param>
+        public ResultData<StartResult> Start(StartParameters parameters)
+        {
+            return GetData<StartResult>(new SynologyRequestParameters
+            {
+                Version = 3,
+                Method = "start",
+                Additional = parameters
+            });
+        }
+
+        /// <summary>
+        /// Get the copying/moving status.
+        /// </summary>
+        public ResultData<StatusResult> Status(StatusParameters parameters)
+        {
+            return GetData<StatusResult>(new SynologyRequestParameters
+            {
+                Version = 3,
+                Method = "status",
+                Additional = parameters
+            });
+        }
+
+        /// <summary>
+        /// Stop a copy/move task.
+        /// </summary>
+        public ResultData Stop(StopParameters parameters)
+        {
+            return GetData(new SynologyRequestParameters
+            {
+                Version = 3,
+                Method = "stop",
+                Additional = parameters
+            });
+        }
+    }
+}

--- a/Synology.FileStation/CopyMove/FileStationCopyMoveExtension.cs
+++ b/Synology.FileStation/CopyMove/FileStationCopyMoveExtension.cs
@@ -1,0 +1,19 @@
+﻿using Synology.Extensions;
+using Synology.FileStation;
+using Synology.FileStation.CopyMove;
+
+namespace Synology
+{
+    public static class FileStationCopyMoveExtension
+    {
+        /// <summary>
+        /// Copy or Move API operations
+        /// </summary>
+        /// <param name="api"></param>
+        /// <returns></returns>
+        public static CopyMoveRequest CopyMove(this FileStationApi api)
+        {
+            return RequestExtension<CopyMoveRequest>.Request(api);
+        }
+    }
+}

--- a/Synology.FileStation/CopyMove/Parameters/StartParameters.cs
+++ b/Synology.FileStation/CopyMove/Parameters/StartParameters.cs
@@ -1,0 +1,78 @@
+﻿using Synology.Utilities;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Newtonsoft.Json;
+using Synology.Parameters;
+
+namespace Synology.FileStation.CopyMove.Parameters
+{
+    public class StartParameters : RequestParameters
+    {
+        /// <summary>
+        /// One or more files or folder to move / copy
+        /// </summary>
+        /// <remarks>
+        /// One or more copied/moved file/folder path(s) starting with a shared folder, separated by commas ","and around brackets.
+        /// </remarks>
+        [Required]
+        public IEnumerable<string> Path { get; set; }
+
+        /// <summary>
+        /// The destination folder to which files or folders are to be copied / moved
+        /// </summary>
+        /// <remarks>
+        /// A desitination folder path where files/folders are copied/moved.
+        /// </remarks>
+        [Required]
+        [JsonProperty("dest_folder_path")]
+        public string DestinationFolder { get; set; }
+
+        /// <summary>
+        /// Overwrite existing files / folders
+        /// </summary>
+        /// <remarks>
+        /// Optional. "true": overwrite all existing files with the same name; "false": skip all existing files with the same name; (None): do not overwrite or skip existed files. If there is any existing files, an error occurs (error code: 1003).
+        /// </remarks>
+        public bool? Overwrite { get; set; }
+
+        /// <summary>
+        /// Mark the operation as a move operation
+        /// </summary>
+        /// <remarks>
+        /// Optional. "true": move filess/folders; "false": copy files/folders
+        /// </remarks>
+        [JsonProperty("remove_src")]
+        public bool Move { get; set; }
+
+        /// <summary>
+        /// Precision of the progress calculation
+        /// </summary>
+        /// <remarks>
+        /// Optional. "true": calculate the progress by each moved/copied file within subfolder. "false": calculate the progress by files which you give in path parameters. This calculates the progress faster, but is less precise.
+        /// </remarks>
+        [JsonProperty("accurate_progress")]
+        public bool AccurateProgress { get; set; }
+
+        /// <summary>
+        /// Search Id from which the files are to be copied / move
+        /// </summary>
+        /// <remarks>
+        /// Optional. A unique ID for the search task which is gotten from SYNO.FileSation.Search API with start method. This is used to update the search result.
+        /// </remarks>
+        [JsonProperty("search_taskid")]
+        public string SearchTaskId { get; set; }
+
+        public override QueryStringParameter[] Parameters()
+        {
+            return new[]
+            {
+                new QueryStringParameter("path", Path, true),
+                new QueryStringParameter("dest_folder_path", DestinationFolder),
+                new QueryStringParameter("overwrite", Overwrite),
+                new QueryStringParameter("remove_src", Move),
+                new QueryStringParameter("accurate_progress", AccurateProgress),
+                new QueryStringParameter("search_taskid", SearchTaskId),
+            };
+        }
+    }
+}

--- a/Synology.FileStation/CopyMove/Parameters/StatusParameters.cs
+++ b/Synology.FileStation/CopyMove/Parameters/StatusParameters.cs
@@ -1,0 +1,26 @@
+﻿using Synology.Parameters;
+using Synology.Utilities;
+using System.ComponentModel.DataAnnotations;
+
+namespace Synology.FileStation.CopyMove.Parameters
+{
+    public class StatusParameters : RequestParameters
+    {
+        /// <summary>
+        /// The task id from which status has to be retrieved.
+        /// </summary>
+        /// <remarks>
+        /// A unique ID for the copy/move task which is obtained from start method.
+        /// </remarks>
+        [Required]
+        public string TaskId { get; set; }
+
+        public override QueryStringParameter[] Parameters()
+        {
+            return new[]
+            {
+                new QueryStringParameter("taskid", TaskId)
+            };
+        }
+    }
+}

--- a/Synology.FileStation/CopyMove/Parameters/StopParameters.cs
+++ b/Synology.FileStation/CopyMove/Parameters/StopParameters.cs
@@ -1,0 +1,26 @@
+﻿using Synology.Parameters;
+using Synology.Utilities;
+using System.ComponentModel.DataAnnotations;
+
+namespace Synology.FileStation.CopyMove.Parameters
+{
+    public class StopParameters : RequestParameters
+    {
+        /// <summary>
+        /// The task id to be stopped.
+        /// </summary>
+        /// <remarks>
+        /// A unique ID for the copy/move task which is obtained from start method.
+        /// </remarks>
+        [Required]
+        public string TaskId { get; set; }
+
+        public override QueryStringParameter[] Parameters()
+        {
+            return new[]
+            {
+                new QueryStringParameter("taskid", TaskId)
+            };
+        }
+    }
+}

--- a/Synology.FileStation/CopyMove/Results/StartResult.cs
+++ b/Synology.FileStation/CopyMove/Results/StartResult.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Synology.FileStation.CopyMove.Results
+{
+    public class StartResult
+    {
+        [JsonProperty("taskid")]
+        public string TaskId { get; set; }
+    }
+}

--- a/Synology.FileStation/CopyMove/Results/StatusResult.cs
+++ b/Synology.FileStation/CopyMove/Results/StatusResult.cs
@@ -1,0 +1,43 @@
+﻿using Newtonsoft.Json;
+
+namespace Synology.FileStation.CopyMove.Results
+{
+    public class StatusResult
+    {
+        /// <summary>
+        /// If accurate_progress parameter is "true," byte sizes of all copied/moved files will be accumulated.If "false," only byte sizes of the file you give in path parameter is accumulated.
+        /// </summary>
+        [JsonProperty("processed_size")]
+        public int ProgressSize { get; set; }
+
+        /// <summary>
+        /// If accurate_progress parameter is "true," the value indicates total byte sizes of files including subfolders will be copied/moved.If "false," it indicates total byte sizes of files you give in path parameter excluding files within subfolders. Otherwise, when the total number is calculating, the value is -1.
+        /// </summary>
+        [JsonProperty("total")]
+        public int ProgressTotal { get; set; }
+
+        /// <summary>
+        /// A copying/moving path which you give in path parameter
+        /// </summary>
+        [JsonProperty("path")]
+        public string Path { get; set; }
+
+        /// <summary>
+        /// If the copy/move task is finished or not
+        /// </summary>
+        [JsonProperty("finished")]
+        public bool Finished { get; set; }
+
+        /// <summary>
+        /// A progress value is between 0~1. It is equal to processed_size parameter divided by total parameter
+        /// </summary>
+        [JsonProperty("progress")]
+        public double ProgressPercent { get; set; }
+
+        /// <summary>
+        /// A desitination folder path where files/folders are copied/moved.
+        /// </summary>
+        [JsonProperty("dest_folder_path")]
+        public string DestinationFolder { get; set; }
+    }
+}

--- a/Synology.FileStation/Rename/FileStationRenameExtension.cs
+++ b/Synology.FileStation/Rename/FileStationRenameExtension.cs
@@ -1,0 +1,14 @@
+﻿using Synology.Extensions;
+using Synology.FileStation;
+using Synology.FileStation.Rename;
+
+namespace Synology
+{
+    public static class FileStationRenameExtension
+    {
+        public static RenameRequest Rename(this FileStationApi api)
+        {
+            return RequestExtension<RenameRequest>.Request(api);
+        }
+    }
+}

--- a/Synology.FileStation/Rename/Parameters/RenameAdditional.cs
+++ b/Synology.FileStation/Rename/Parameters/RenameAdditional.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Synology.FileStation.Rename.Parameters
+{
+    [Flags]
+    public enum RenameAdditional
+    {
+        /// <summary>
+        /// Return a real path in volume
+        /// </summary>
+        [Description("real_path")]
+        RealPath = 1 << 0,
+        /// <summary>
+        /// Return file byte size
+        /// </summary>
+        [Description("size")]
+        Size = 1 << 1,
+        /// <summary>
+        ///  Return information about file owner including user name, group name, UID and GID
+        /// </summary>
+        [Description("owner")]
+        Owner = 1 << 2,
+        /// <summary>
+        /// Return information about time including last access time, last modified time, last change time and create time
+        /// </summary>
+        [Description("time")]
+        Time = 1 << 3,
+        /// <summary>
+        /// Return information about file permission
+        /// </summary>
+        [Description("perm")]
+        Perm = 1 << 4,
+        /// <summary>
+        /// Return a file extension
+        /// </summary>
+        [Description("type")]
+        Type = 1 << 5
+    }
+}

--- a/Synology.FileStation/Rename/Parameters/RenameParameters.cs
+++ b/Synology.FileStation/Rename/Parameters/RenameParameters.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using Synology.Utilities;
+using System.ComponentModel.DataAnnotations;
+using Synology.Parameters;
+
+namespace Synology.FileStation.Rename.Parameters
+{
+    public class RenameParameters : RequestParameters
+    {
+        /// <summary>
+        /// One or more file or folder path to rename
+        /// </summary>
+        /// <remarks>
+        /// One or more paths of files/folders to be renamed, separated by commas "," and around brackets.The number of paths must be the same as the number of names in the name parameter.The first path parameter corresponds to the first name parameter.
+        /// </remarks>
+        [Required]
+        public IEnumerable<string> Path { get; set; }
+
+        /// <summary>
+        /// One or more new names
+        /// </summary>
+        /// <remarks>
+        /// One or more new names, separated by commas "," and around brackets. The number of names must be the same as the number of folder paths in the path parameter.The first name parameter corresponding to the first path parameter.
+        /// </remarks>
+        [Required]
+        public IEnumerable<string> Name { get; set; }
+
+        /// <summary>
+        /// Additional informations to be retrieved
+        /// </summary>
+        /// <remarks>
+        /// Optional. Additional requested file information, separated by commas "," and around brackets. When an additional option is requested, responded objects will be provided in the specified additional option.
+        /// </remarks>
+        public RenameAdditional Additional { get; set; }
+
+        /// <summary>
+        /// The search task id to be updated by the rename
+        /// </summary>
+        /// <remarks>
+        /// Optional. A unique ID for the search task which is obtained from start method.It is used to update the renamed file in the search result.
+        /// </remarks>
+        public string SearchTaskId { get; set; }
+
+        public override QueryStringParameter[] Parameters()
+        {
+            return new[]
+            {
+                new QueryStringParameter("path", Path, true),
+                new QueryStringParameter("name", Name, true),
+                new QueryStringParameter("additional", Additional, true),
+                new QueryStringParameter("search_taskid", SearchTaskId),
+            };
+        }
+    }
+}

--- a/Synology.FileStation/Rename/RenameRequest.cs
+++ b/Synology.FileStation/Rename/RenameRequest.cs
@@ -1,0 +1,29 @@
+﻿using Synology.Classes;
+using Synology.FileStation.FileShare.Results;
+using Synology.FileStation.Rename.Parameters;
+using Synology.Parameters;
+
+namespace Synology.FileStation.Rename
+{
+    public class RenameRequest : SynologyRequest
+    {
+        public RenameRequest(SynologyApi api) : base(api, "entry.cgi", "FileStation.Rename")
+        {
+        }
+
+        /// <summary>
+        /// Rename a file/folder
+        /// </summary>
+        /// <param name="parameters"></param>
+        /// <returns></returns>
+        public ResultData<FileResult> Rename(RenameParameters parameters)
+        {
+            return GetData<FileResult>(new SynologyRequestParameters
+            {
+                Version = 2,
+                Method = "rename",
+                Additional = parameters
+            });
+        }
+    }
+}

--- a/Synology.FileStation/Synology.FileStation.csproj
+++ b/Synology.FileStation/Synology.FileStation.csproj
@@ -41,6 +41,13 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CopyMove\CopyMoveRequest.cs" />
+    <Compile Include="CopyMove\FileStationCopyMoveExtension.cs" />
+    <Compile Include="CopyMove\Parameters\StartParameters.cs" />
+    <Compile Include="CopyMove\Parameters\StatusParameters.cs" />
+    <Compile Include="CopyMove\Parameters\StopParameters.cs" />
+    <Compile Include="CopyMove\Results\StartResult.cs" />
+    <Compile Include="CopyMove\Results\StatusResult.cs" />
     <Compile Include="FileStationRequest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="FileShare\Results\FileAdditionalResult.cs" />
@@ -64,6 +71,10 @@
     <Compile Include="Info\FileStationInfoExtension.cs" />
     <Compile Include="Info\InfoRequest.cs" />
     <Compile Include="Info\Results\InfoResult.cs" />
+    <Compile Include="Rename\FileStationRenameExtension.cs" />
+    <Compile Include="Rename\Parameters\RenameAdditional.cs" />
+    <Compile Include="Rename\Parameters\RenameParameters.cs" />
+    <Compile Include="Rename\RenameRequest.cs" />
     <Compile Include="Search\FileStationSearchExtension.cs" />
     <Compile Include="Search\Results\SearchListResult.cs" />
     <Compile Include="Search\SearchRequest.cs" />

--- a/Synology.Tests/QueryStringManagerTests.cs
+++ b/Synology.Tests/QueryStringManagerTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Synology.Utilities;
 
 namespace Synology.Tests
@@ -10,7 +9,7 @@ namespace Synology.Tests
         [TestMethod]
         public void QueryStringManagerArrayTest()
         {
-            var manager = new QueryStringManager("http://test.com");
+            QueryStringManager manager = new QueryStringManager("http://test.com");
 
             manager.AddParameter(new QueryStringParameter("arrayParam", new string[] { "testString1", "testString2" }));
 

--- a/Synology.Tests/QueryStringParameterTests.cs
+++ b/Synology.Tests/QueryStringParameterTests.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Synology.Utilities;
+
+namespace Synology.Tests
+{
+    [TestClass]
+    public class QueryStringParameterTests
+    {
+        [TestMethod]
+        public void TestEmptyParameters()
+        {
+            var parameter = new QueryStringParameter("param", string.Empty);
+            var parameter2 = new QueryStringParameter(string.Empty, "param");
+
+            Assert.AreEqual(string.Empty, parameter.ToString());
+            Assert.AreEqual(string.Empty, parameter2.ToString());
+            Assert.AreEqual(parameter.ToString(), parameter2.ToString());
+        }
+
+        [TestMethod]
+        public void TestEnum()
+        {
+            var parameter = new QueryStringParameter("param", Synology.Tests.TestEnum.Test1 | Synology.Tests.TestEnum.Test2);
+
+            var result = parameter.ToString();
+
+            Assert.AreEqual("param=test1,test2", result);
+        }
+
+        [TestMethod]
+        public void TestEnumBrackets()
+        {
+            var parameter = new QueryStringParameter("param", Synology.Tests.TestEnum.Test1 | Synology.Tests.TestEnum.Test2, true);
+
+            var result = parameter.ToString();
+
+            Assert.AreEqual("param=[test1,test2]", result);
+        }
+
+        [TestMethod]
+        public void TestEnumerables()
+        {
+            var parameter = new QueryStringParameter("param", new[] { "test1", "test2" });
+
+            var result = parameter.ToString();
+
+            Assert.AreEqual("param=test1,test2", result);
+        }
+
+        [TestMethod]
+        public void TestEnumerablesBrackets()
+        {
+            var parameter = new QueryStringParameter("param", new[] { "test1", "test2" }, true);
+
+            var result = parameter.ToString();
+
+            Assert.AreEqual("param=[test1,test2]", result);
+        }
+    }
+
+    [Flags]
+    public enum TestEnum
+    {
+        [System.ComponentModel.Description("test1")]
+        Test1 = 1 << 0,
+
+        [System.ComponentModel.Description("test2")]
+        Test2 = 1 << 2,
+
+        [System.ComponentModel.Description("test3")]
+        Test3 = 1 << 3,
+    }
+}

--- a/Synology.Tests/Synology.Tests.csproj
+++ b/Synology.Tests/Synology.Tests.csproj
@@ -65,6 +65,7 @@
   <ItemGroup>
     <Compile Include="QueryStringManagerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="QueryStringParameterTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Synology.Api\Synology.Api.csproj">

--- a/Synology/Utilities/GenericParameter.cs
+++ b/Synology/Utilities/GenericParameter.cs
@@ -21,10 +21,11 @@ namespace Synology.Utilities
         /// </summary>
         /// <param name="name">Name of the parameter</param>
         /// <param name="value">Value of the parameter</param>
-        protected GenericParameter(string name, string value)
+        /// <param name="surroundBrackets">Surround parameter value(s) by brackets</param>
+        protected GenericParameter(string name, string value, bool surroundBrackets = false)
         {
             Name = name;
-            Value = value;
+            Value = surroundBrackets ? $"[{value}]" : value;
         }
 
         protected GenericParameter(string name, int? value) : this(name, value?.ToString())
@@ -83,7 +84,15 @@ namespace Synology.Utilities
         {
         }
 
+        protected GenericParameter(string name, IEnumerable<string> value, bool surroundBrackets) : this(name, value, ",", surroundBrackets)
+        {
+        }
+
         protected GenericParameter(string name, IEnumerable<string> value, string separator) : this(name, string.Join(separator, value))
+        {
+        }
+
+        protected GenericParameter(string name, IEnumerable<string> value, string separator, bool surroundBrackets) : this(name, string.Join(separator, value), surroundBrackets)
         {
         }
 

--- a/Synology/Utilities/QueryStringParameter.cs
+++ b/Synology/Utilities/QueryStringParameter.cs
@@ -9,7 +9,7 @@ namespace Synology.Utilities
 {
     public sealed class QueryStringParameter : GenericParameter
     {
-        public QueryStringParameter(string name, string value) : base(name, value)
+        public QueryStringParameter(string name, string value, bool surroundBrackets = false) : base(name, value, surroundBrackets)
         {
         }
 
@@ -62,6 +62,10 @@ namespace Synology.Utilities
         }
 
         public QueryStringParameter(string name, Enum value) : this(name, GetEnumDescription(value))
+        {
+        }
+
+        public QueryStringParameter(string name, Enum value, bool surroundBrackets) : this(name, GetEnumDescription(value), surroundBrackets)
         {
         }
 
@@ -118,6 +122,10 @@ namespace Synology.Utilities
         }
 
         public QueryStringParameter(string name, IEnumerable<string> value) : base(name, value)
+        {
+        }
+
+        public QueryStringParameter(string name, IEnumerable<string> value, bool surroundBrackets) : base(name, value, surroundBrackets)
         {
         }
 


### PR DESCRIPTION
- Added support for both CopyMove and Rename FileStation API methods.
- Added contructors on QueryStringParameter and GenericParameter classes to enable the usage of brackets array values "[value1,value2]"
- Added unit tests to ensure no regression introduced in the contructors (more has to be added to complete the work).
